### PR TITLE
HoverTrailer v0.2.0 - Jellyfin 10.11 Compatibility + Critical Bug Fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
         new_entry = {
             "version": version,
             "changelog": changelog,
-            "targetAbi": "10.10.0.0",
+            "targetAbi": "10.11.0.0",
             "sourceUrl": f"https://github.com/Fovty/HoverTrailer/releases/download/v{version}/HoverTrailer-{version}-server.zip",
             "checksum": checksum,
             "timestamp": timestamp

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 bin/
 obj/
 artifacts/
+publish/
 
 # IDEs
 .vs/

--- a/.vscode/deploy.bat
+++ b/.vscode/deploy.bat
@@ -12,8 +12,8 @@ set REMOTE_HOST=%JELLYFIN_REMOTE_HOST%
 set REMOTE_USER=%JELLYFIN_REMOTE_USER%
 set REMOTE_PATH=%JELLYFIN_REMOTE_PATH%
 set BUILD_CONFIG=Debug
-set TARGET_FRAMEWORK=net8.0
-set BUILD_OUTPUT=./Fovty.Plugin.HoverTrailer/bin/Debug/net8.0/publish
+set TARGET_FRAMEWORK=net9.0
+set BUILD_OUTPUT=./Fovty.Plugin.HoverTrailer/bin/Debug/net9.0/publish
 set PROJECT_FILE=./Fovty.Plugin.HoverTrailer.sln
 
 echo === HoverTrailer Plugin Deployment ===

--- a/.vscode/deploy.sh
+++ b/.vscode/deploy.sh
@@ -15,8 +15,8 @@ REMOTE_HOST="${JELLYFIN_REMOTE_HOST}"
 REMOTE_USER="${JELLYFIN_REMOTE_USER}"
 REMOTE_PATH="${JELLYFIN_REMOTE_PATH}"
 BUILD_CONFIG="Debug"
-TARGET_FRAMEWORK="net8.0"
-BUILD_OUTPUT="./Fovty.Plugin.HoverTrailer/bin/Debug/net8.0/publish"
+TARGET_FRAMEWORK="net9.0"
+BUILD_OUTPUT="./Fovty.Plugin.HoverTrailer/bin/Debug/net9.0/publish"
 PROJECT_FILE="./Fovty.Plugin.HoverTrailer.sln"
 
 # Check for JELLYFIN_REMOTE_PASSWORD environment variable
@@ -51,6 +51,7 @@ clean_build() {
     echo -e "${YELLOW}Cleaning previous build...${NC}"
 
     # Clean using dotnet clean
+    export PATH="/home/user/.dotnet:$PATH"
     dotnet clean "$PROJECT_FILE" -c "$BUILD_CONFIG"
     if [ $? -ne 0 ]; then echo -e "${RED}❌ Dotnet clean failed${NC}"; exit 1; fi
 
@@ -64,6 +65,7 @@ clean_build() {
 
 build_plugin() {
     echo -e "${YELLOW}Building plugin...${NC}"
+    export PATH="/home/user/.dotnet:$PATH"
     dotnet publish "$PROJECT_FILE" -c "$BUILD_CONFIG" -f "$TARGET_FRAMEWORK" \
         --property:TreatWarningsAsErrors=false \
         /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,51 +3,31 @@
     "configurations": [
         {
             "name": "Clean Build and Deploy HoverTrailer",
-            "type": "coreclr",
+            "type": "node-terminal",
             "request": "launch",
-            "preLaunchTask": "build-and-deploy",
-            "program": "dotnet",
-            "args": [],
-            "cwd": "${workspaceFolder}",
-            "stopAtEntry": false,
-            "console": "internalConsole",
-            "internalConsoleOptions": "openOnSessionStart"
+            "command": "echo 'Task complete! Check the terminal output above for results.'; exit 0",
+            "preLaunchTask": "build-and-deploy"
         },
         {
             "name": "Quick Deploy (No Build)",
-            "type": "coreclr",
+            "type": "node-terminal",
             "request": "launch",
-            "preLaunchTask": "quick-deploy",
-            "program": "dotnet",
-            "args": [],
-            "cwd": "${workspaceFolder}",
-            "stopAtEntry": false,
-            "console": "internalConsole",
-            "internalConsoleOptions": "openOnSessionStart"
+            "command": "echo 'Task complete! Check the terminal output above for results.'; exit 0",
+            "preLaunchTask": "quick-deploy"
         },
         {
             "name": "Full Deploy (Clean + Build + Deploy + Restart)",
-            "type": "coreclr",
+            "type": "node-terminal",
             "request": "launch",
-            "preLaunchTask": "full-deploy",
-            "program": "dotnet",
-            "args": [],
-            "cwd": "${workspaceFolder}",
-            "stopAtEntry": false,
-            "console": "internalConsole",
-            "internalConsoleOptions": "openOnSessionStart"
+            "command": "echo 'Task complete! Check the terminal output above for results.'; exit 0",
+            "preLaunchTask": "full-deploy"
         },
         {
             "name": "Clean Build Only",
-            "type": "coreclr",
+            "type": "node-terminal",
             "request": "launch",
-            "preLaunchTask": "clean-build",
-            "program": "dotnet",
-            "args": [],
-            "cwd": "${workspaceFolder}",
-            "stopAtEntry": false,
-            "console": "internalConsole",
-            "internalConsoleOptions": "openOnSessionStart"
+            "command": "echo 'Task complete! Check the terminal output above for results.'; exit 0",
+            "preLaunchTask": "clean-build"
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,10 +6,10 @@
 
     // Build configuration
     "buildConfiguration": "Debug",
-    "targetFramework": "net8.0",
+    "targetFramework": "net9.0",
 
     // Local build paths
-    "buildOutputPath": "./Fovty.Plugin.HoverTrailer/bin/Debug/net8.0/publish",
+    "buildOutputPath": "./Fovty.Plugin.HoverTrailer/bin/Debug/net9.0/publish",
     "projectFile": "./Fovty.Plugin.HoverTrailer.sln",
     "pluginDllName": "Fovty.Plugin.HoverTrailer.dll"
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>0.1.1.0</Version>
-        <AssemblyVersion>0.1.1.0</AssemblyVersion>
-        <FileVersion>0.1.1.0</FileVersion>
+        <Version>0.2.0.0</Version>
+        <AssemblyVersion>0.2.0.0</AssemblyVersion>
+        <FileVersion>0.2.0.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/Fovty.Plugin.HoverTrailer/Api/HoverTrailerController.cs
+++ b/Fovty.Plugin.HoverTrailer/Api/HoverTrailerController.cs
@@ -401,6 +401,7 @@ public class HoverTrailerController : ControllerBase
     'use strict';
 
     const BASE_PATH = '{basePath}';
+    const API_BASE_URL = window.location.origin + BASE_PATH;
     const HOVER_DELAY = {config.HoverDelayMs};
     const DEBUG_LOGGING = {config.EnableDebugLogging.ToString().ToLower()};
     const PREVIEW_POSITIONING_MODE = '{config.PreviewPositioningMode}';
@@ -563,7 +564,7 @@ public class HoverTrailerController : ControllerBase
         log('Showing preview for movie:', movieId);
 
         // Get trailer info from API
-        fetch(`${{BASE_PATH}}/HoverTrailer/TrailerInfo/${{movieId}}`)
+        fetch(`${{API_BASE_URL}}/HoverTrailer/TrailerInfo/${{movieId}}`)
             .then(response => {{
                 if (!response.ok) {{
                     throw new Error('Trailer not found');
@@ -571,7 +572,7 @@ public class HoverTrailerController : ControllerBase
                 return response.json();
             }})
             .then(trailerInfo => {{
-                const container = createVideoPreview(`${{BASE_PATH}}/Videos/${{trailerInfo.Id}}/stream`, element);
+                const container = createVideoPreview(`${{API_BASE_URL}}/Videos/${{trailerInfo.Id}}/stream`, element);
                 const video = container.querySelector('video');
 
                 video.addEventListener('loadeddata', () => {{

--- a/Fovty.Plugin.HoverTrailer/Fovty.Plugin.HoverTrailer.csproj
+++ b/Fovty.Plugin.HoverTrailer/Fovty.Plugin.HoverTrailer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Fovty.Plugin.HoverTrailer</RootNamespace>
     <AssemblyName>Fovty.Plugin.HoverTrailer</AssemblyName>
     <EnableDynamicLoading>true</EnableDynamicLoading>
@@ -23,8 +23,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.10.*-*" />
-    <PackageReference Include="Jellyfin.Model" Version="10.10.*-*" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.*-*" />
+    <PackageReference Include="Jellyfin.Model" Version="10.11.*-*" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
### Overview
This release updates HoverTrailer for Jellyfin 10.11.* compatibility and resolves two critical issues affecting plugin functionality in production environments.

---

### ✨ What's New

#### **Jellyfin 10.11.* Support**
- Updated target framework from .NET 8.0 to .NET 9.0
- Updated Jellyfin.Controller and Jellyfin.Model dependencies to 10.11.*
- Updated build configurations and deployment scripts
- Updated release workflow to target ABI 10.11.0.0

#### **File Transformation Plugin Integration** 🆕
- Automatic runtime detection of File Transformation plugin (v2.2.1.0+)
- Reflection-based registration for zero-configuration setup
- Runtime HTML transformation without file modification
- Graceful fallback to direct injection if File Transformation unavailable
- Eliminates Docker permission issues permanently

---

### 🐛 Bug Fixes

#### **Issue #1: TypeError: Failed to construct 'URL': Invalid URL**
**Problem:** Jellyfin's web client `DataFetcher` requires absolute URLs but was receiving relative paths like `/HoverTrailer/TrailerInfo/{id}`, causing fatal JavaScript errors.

**Solution:**
- Introduced `API_BASE_URL` constant: `window.location.origin + BASE_PATH`
- Updated all fetch calls to use absolute URLs
- Compatible with reverse proxies and custom base paths

**Files Changed:**
- [`HoverTrailerController.cs`](Fovty.Plugin.HoverTrailer/Api/HoverTrailerController.cs:403-407)

**Impact:** ✅ Resolves trailer loading failures in all deployment configurations

---

#### **Issue #2: Docker Permission Denied on index.html**
**Problem:** Direct modification of `/usr/share/jellyfin/web/index.html` fails in Docker environments due to file ownership and read-only filesystems.

**Solution:**
- Implemented File Transformation plugin integration via reflection
- Transforms HTML at runtime without touching disk files
- Falls back to direct injection if File Transformation unavailable
- Clean debug logging (verbose logs only in debug mode)

**Files Changed:**
- [`Plugin.cs`](Fovty.Plugin.HoverTrailer/Plugin.cs:169-285) - Added `TryRegisterFileTransformation()` and `TransformIndexHtmlCallback()`
- [`Fovty.Plugin.HoverTrailer.csproj`](Fovty.Plugin.HoverTrailer/Fovty.Plugin.HoverTrailer.csproj:28) - Added Newtonsoft.Json dependency
- [`README.md`](README.md:110-149) - Comprehensive Docker troubleshooting documentation

**Impact:** ✅ Works in Docker with read-only web directories, survives Jellyfin updates

---

### 📊 Testing Checklist

- [x] Jellyfin 10.11.0 compatibility verified
- [x] Issue #1 resolved - Fetch calls use absolute URLs
- [x] Issue #2 resolved - File Transformation integration working
- [x] Backward compatibility - Falls back gracefully if File Transformation unavailable
- [x] Debug logging clean and appropriate
- [x] Documentation updated with troubleshooting steps

---

⚠️ **Jellyfin 10.10 and earlier are no longer supported**
- Minimum version: Jellyfin 10.11.0
- Requires .NET 9.0 runtime
- Users on Jellyfin 10.10 should use HoverTrailer v0.1.x